### PR TITLE
[GST-7010] Make graphql codegen optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Serverless plugin for zero-config Typescript with support for [tsoa](https://tso
 * Supports `sls package`, `sls deploy` and `sls deploy function`
 * Supports `sls invoke local` + `--watch` mode
 * Integrates nicely with [`serverless-offline`](https://github.com/dherault/serverless-offline)
-* Generates GraphQL types for file extensions `.gql` and `.graphql` (uses codegen)
+* Generates GraphQL types for file extensions `.gql` and `.graphql` (uses codegen). This is skipped if no `codegen.yml` file is found on the root of the project.
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-typescript-tsoa-gql",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "license": "MIT",
   "main": "dist/src/index.js",
   "files": [
@@ -28,28 +28,28 @@
   "devDependencies": {
     "@graphql-codegen/cli": "^2.2.2",
     "@graphql-codegen/typescript": "2.3.1",
-    "@types/fs-extra": "5.0.5",
+    "@types/fs-extra": "10.1.0",
     "@types/jest": "24.0.12",
-    "@types/lodash": "4.14.123",
-    "@types/node": "12.6.2",
+    "@types/lodash": "4.14.190",
+    "@types/node": "14.14.20",
     "graphql": "^15.3.0",
     "jest": "24.5.0",
     "mock-fs": "4.9.0",
     "rimraf": "2.6.3",
     "ts-jest": "24.0.2",
     "tslint": "5.14.0",
-    "tsoa": "^3.6.1",
-    "typescript": "^4.2.0"
+    "tsoa": "^3.14.1",
+    "typescript": "^4.9.3"
   },
   "dependencies": {
-    "fs-extra": "^7.0.1",
-    "globby": "^9.2.0",
+    "fs-extra": "^10.1.0",
+    "globby": "^11.0.4",
     "js-yaml": "^4.1.0",
-    "lodash": "^4.17.11",
-    "shelljs": "^0.8.4"
+    "lodash": "^4.17.21",
+    "shelljs": "^0.8.5"
   },
   "peerDependencies": {
-    "typescript": ">=4.2.0"
+    "typescript": ">=4.9.3"
   },
   "jest": {
     "preset": "ts-jest",

--- a/src/Serverless.d.ts
+++ b/src/Serverless.d.ts
@@ -1,46 +1,46 @@
 declare namespace Serverless {
   interface Instance {
     cli: {
-      log(str: string): void
-    }
+      log(str: string): void;
+    };
 
     config: {
-      servicePath: string
-    }
+      servicePath: string;
+    };
 
     service: {
       provider: {
-        name: string
-      }
+        name: string;
+      };
       functions: {
-        [key: string]: Serverless.Function
-      }
-      package: Serverless.Package
-      getAllFunctions(): string[]
-    }
+        [key: string]: Serverless.Function;
+      };
+      package: Serverless.Package;
+      getAllFunctions(): string[];
+    };
 
-    pluginManager: PluginManager
+    pluginManager: PluginManager;
   }
 
   interface Options {
-    function?: string
-    watch?: boolean
-    extraServicePath?: string
+    function?: string;
+    watch?: boolean;
+    extraServicePath?: string;
   }
 
   interface Function {
-    handler: string
-    package: Serverless.Package
+    handler: string;
+    package: Serverless.Package;
   }
 
   interface Package {
-    include: string[]
-    exclude: string[]
-    artifact?: string
-    individually?: boolean
+    include: string[];
+    exclude: string[];
+    artifact?: string;
+    individually?: boolean;
   }
 
   interface PluginManager {
-    spawn(command: string): Promise<void>
+    spawn(command: string): Promise<void>;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ import * as _ from 'lodash';
 import * as globby from 'globby';
 import * as ts from 'typescript';
 import * as yaml from 'js-yaml';
-import * as gqlCli from '@graphql-codegen/cli';
 
 import { generateRoutes, generateSpec } from 'tsoa';
 
@@ -168,21 +167,26 @@ export class TypeScriptPlugin {
   }
 
   async generateGraphqlTypes() {
-    this.serverless.cli.log('Generate graphql types...');
     const { generates } = this.getGqlCodegenConfig(
       this.originalServicePath,
       this.isWatching ? null : this.serverless.cli
     );
 
-    await gqlCli.generate(
-      {
-        schema: this.graphqlFilePaths,
-        generates,
-      },
-      true
-    );
+    if (generates) {
+      this.serverless.cli.log('Generate graphql types...');
 
-    this.serverless.cli.log('GraphQL Types Generation Complete...');
+      const gqlCli = require('@graphql-codegen/cli');
+
+      await gqlCli.generate(
+        {
+          schema: this.graphqlFilePaths,
+          generates,
+        },
+        true
+      );
+
+      this.serverless.cli.log('GraphQL Types Generation Complete...');
+    }
   }
 
   async watchFunction(): Promise<void> {
@@ -420,7 +424,7 @@ export class TypeScriptPlugin {
       routesDir: 'build',
       authenticationModule: 'api/middleware/auth.ts',
     };
-    let ignorePaths = undefined;
+    let ignorePaths;
     let logMessage = `No ${TSOA_CONFIG_FILE} config found, using defaults...`;
     const configFilePath = path.join(cwd, TSOA_CONFIG_FILE);
 

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -1,7 +1,7 @@
-import * as ts from 'typescript'
-import * as fs from 'fs-extra'
-import * as _ from 'lodash'
-import * as path from 'path'
+import * as ts from 'typescript';
+import * as fs from 'fs-extra';
+import * as _ from 'lodash';
+import * as path from 'path';
 
 export function makeDefaultTypescriptConfig() {
   const defaultTypescriptConfig: ts.CompilerOptions = {
@@ -13,12 +13,16 @@ export function makeDefaultTypescriptConfig() {
     moduleResolution: ts.ModuleResolutionKind.NodeJs,
     lib: ['lib.es2015.d.ts'],
     rootDir: './',
-  }
+  };
 
-  return defaultTypescriptConfig
+  return defaultTypescriptConfig;
 }
 
-export function extractFileNames(cwd: string, provider: string, functions?: { [key: string]: Serverless.Function }): string[] {
+export function extractFileNames(
+  cwd: string,
+  provider: string,
+  functions?: { [key: string]: Serverless.Function }
+): string[] {
   // The Google provider will use the entrypoint not from the definition of the
   // handler function, but instead from the package.json:main field, or via a
   // index.js file. This check reads the current package.json in the same way
@@ -26,72 +30,89 @@ export function extractFileNames(cwd: string, provider: string, functions?: { [k
   // working directory. If the packageFile does not contain a valid main, then
   // it instead selects the index.js file.
   if (provider === 'google') {
-    const packageFilePath = path.join(cwd, 'package.json')
+    const packageFilePath = path.join(cwd, 'package.json');
     if (fs.existsSync(packageFilePath)) {
-
       // Load in the package.json file.
-      const packageFile = JSON.parse(fs.readFileSync(packageFilePath).toString())
+      const packageFile = JSON.parse(
+        fs.readFileSync(packageFilePath).toString()
+      );
 
       // Either grab the package.json:main field, or use the index.ts file.
       // (This will be transpiled to index.js).
-      const main = packageFile.main ? packageFile.main.replace(/\.js$/, '.ts') : 'index.ts'
+      const main = packageFile.main
+        ? packageFile.main.replace(/\.js$/, '.ts')
+        : 'index.ts';
 
       // Check that the file indeed exists.
       if (!fs.existsSync(path.join(cwd, main))) {
-        console.log(`Cannot locate entrypoint, ${main} not found`)
-        throw new Error('Typescript compilation failed')
+        console.log(`Cannot locate entrypoint, ${main} not found`);
+        throw new Error('Typescript compilation failed');
       }
 
-      return [main]
+      return [main];
     }
   }
 
   return _.values(functions)
-    .map(fn => fn.handler)
-    .map(h => {
-      const fnName = _.last(h.split('.'))
-      const fnNameLastAppearanceIndex = h.lastIndexOf(fnName)
+    .map((fn) => fn.handler)
+    .map((h) => {
+      const fnName = _.last(h.split('.'));
+      const fnNameLastAppearanceIndex = h.lastIndexOf(fnName);
       // replace only last instance to allow the same name for file and handler
-      const fileName = h.substring(0, fnNameLastAppearanceIndex)
+      const fileName = h.substring(0, fnNameLastAppearanceIndex);
 
       // Check if the .ts files exists. If so return that to watch
       if (fs.existsSync(path.join(cwd, fileName + 'ts'))) {
-        return fileName + 'ts'
+        return fileName + 'ts';
       }
 
       // Check if the .js files exists. If so return that to watch
       if (fs.existsSync(path.join(cwd, fileName + 'js'))) {
-        return fileName + 'js'
+        return fileName + 'js';
       }
 
       // Can't find the files. Watch will have an exception anyway. So throw one with error.
-      console.log(`Cannot locate handler - ${fileName} not found`)
-      throw new Error('Typescript compilation failed. Please ensure handlers exists with ext .ts or .js')
-    })
+      console.log(`Cannot locate handler - ${fileName} not found`);
+      throw new Error(
+        'Typescript compilation failed. Please ensure handlers exists with ext .ts or .js'
+      );
+    });
 }
 
-export async function run(fileNames: string[], options: ts.CompilerOptions): Promise<string[]> {
-  options.listEmittedFiles = true
-  const program = ts.createProgram(fileNames, options)
+export async function run(
+  fileNames: string[],
+  options: ts.CompilerOptions
+): Promise<string[]> {
+  options.listEmittedFiles = true;
+  const program = ts.createProgram(fileNames, options);
 
-  const emitResult = program.emit()
+  const emitResult = program.emit();
 
-  const allDiagnostics = ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics)
+  const allDiagnostics = ts
+    .getPreEmitDiagnostics(program)
+    .concat(emitResult.diagnostics);
 
-  allDiagnostics.forEach(diagnostic => {
+  allDiagnostics.forEach((diagnostic) => {
     if (!diagnostic.file) {
-      console.log(diagnostic)
+      console.log(diagnostic);
     }
-    const {line, character} = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start)
-    const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')
-    console.log(`${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`)
-  })
+    const { line, character } = diagnostic.file.getLineAndCharacterOfPosition(
+      diagnostic.start
+    );
+    const message = ts.flattenDiagnosticMessageText(
+      diagnostic.messageText,
+      '\n'
+    );
+    console.log(
+      `${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`
+    );
+  });
 
   if (emitResult.emitSkipped) {
-    throw new Error('Typescript compilation failed')
+    throw new Error('Typescript compilation failed');
   }
 
-  return emitResult.emittedFiles.filter(filename => filename.endsWith('.js'))
+  return emitResult.emittedFiles.filter((filename) => filename.endsWith('.js'));
 }
 
 /*
@@ -101,46 +122,54 @@ export function getSourceFiles(
   rootFileNames: string[],
   options: ts.CompilerOptions
 ): string[] {
-  const program = ts.createProgram(rootFileNames, options)
-  const programmFiles = program.getSourceFiles()
-    .map(file => file.fileName)
-    .filter(file => {
-      return file.split(path.sep).indexOf('node_modules') < 0
-    })
-  return programmFiles
+  const program = ts.createProgram(rootFileNames, options);
+  const programmFiles = program
+    .getSourceFiles()
+    .map((file) => file.fileName)
+    .filter((file) => {
+      return file.split(path.sep).indexOf('node_modules') < 0;
+    });
+  return programmFiles;
 }
 
 export function getTypescriptConfig(
   cwd: string,
   logger?: { log: (str: string) => void }
 ): ts.CompilerOptions {
-  const configFilePath = path.join(cwd, 'tsconfig.json')
+  const configFilePath = path.join(cwd, 'tsconfig.json');
 
   if (fs.existsSync(configFilePath)) {
-
-    const configFileText = fs.readFileSync(configFilePath).toString()
-    const result = ts.parseConfigFileTextToJson(configFilePath, configFileText)
+    const configFileText = fs.readFileSync(configFilePath).toString();
+    const result = ts.parseConfigFileTextToJson(configFilePath, configFileText);
     if (result.error) {
-      throw new Error(JSON.stringify(result.error))
+      throw new Error(JSON.stringify(result.error));
     }
 
-    const configParseResult = ts.parseJsonConfigFileContent(result.config, ts.sys, path.dirname(configFilePath))
+    const configParseResult = ts.parseJsonConfigFileContent(
+      result.config,
+      ts.sys,
+      path.dirname(configFilePath)
+    );
     if (configParseResult.errors.length > 0) {
-      throw new Error(JSON.stringify(configParseResult.errors))
+      throw new Error(JSON.stringify(configParseResult.errors));
     }
 
     if (logger) {
-      logger.log(`Using local tsconfig.json`)
+      logger.log(`Using local tsconfig.json`);
     }
 
     // disallow overrriding rootDir
-    if (configParseResult.options.rootDir && path.resolve(configParseResult.options.rootDir) !== path.resolve(cwd) && logger) {
-      logger.log('Warning: "rootDir" from local tsconfig.json is overriden')
+    if (
+      configParseResult.options.rootDir &&
+      path.resolve(configParseResult.options.rootDir) !== path.resolve(cwd) &&
+      logger
+    ) {
+      logger.log('Warning: "rootDir" from local tsconfig.json is overriden');
     }
-    configParseResult.options.rootDir = cwd
+    configParseResult.options.rootDir = cwd;
 
-    return configParseResult.options
+    return configParseResult.options;
   }
 
-  return makeDefaultTypescriptConfig()
+  return makeDefaultTypescriptConfig();
 }

--- a/src/watchFiles.ts
+++ b/src/watchFiles.ts
@@ -1,8 +1,8 @@
 import * as typescript from './typescript';
 import { watchFile, unwatchFile, Stats } from 'fs';
-import globby from 'globby';
-const path = require('path');
-const shell = require('shelljs');
+import * as globby from 'globby';
+import * as path from 'path';
+import * as shell from 'shelljs';
 
 const determineNewWatchFiles = (watchedFiles, newWatchFiles, cb) => {
   watchedFiles.forEach((fileName) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,15 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "lib": [
-      "es2015"
-    ],
+    "lib": ["es2022"],
     "rootDir": ".",
-    "target": "es6",
+    "target": "es2022",
     "sourceMap": true,
     "outDir": "dist",
     "skipLibCheck": true,
     "moduleResolution": "node",
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
+    "emitDecoratorMetadata": true
   },
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -5,7 +5,6 @@
     ],
     "jsRules": {},
     "rules": {
-        "semicolon": [true, "never"],
         "quotemark": [true, "single"],
         "ordered-imports": false,
         "member-access": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1084,14 +1084,6 @@
     "@types/istanbul-lib-coverage" "^1.1.0"
     "@types/yargs" "^12.0.9"
 
-"@mrmlnc/readdir-enhanced@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
-  integrity sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==
-  dependencies:
-    call-me-maybe "^1.0.1"
-    glob-to-regexp "^0.3.0"
-
 "@n1ru4l/graphql-live-query@0.9.0":
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/@n1ru4l/graphql-live-query/-/graphql-live-query-0.9.0.tgz#defaebdd31f625bee49e6745934f36312532b2bc"
@@ -1109,11 +1101,6 @@
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
-
-"@nodelib/fs.stat@^1.1.2":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
-  integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
 "@nodelib/fs.walk@^1.2.3":
   version "1.2.8"
@@ -1205,25 +1192,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/events@*":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
-  integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
-
-"@types/fs-extra@5.0.5":
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-5.0.5.tgz#080d90a792f3fa2c5559eb44bd8ef840aae9104b"
-  integrity sha512-w7iqhDH9mN8eLClQOYTkhdYUOSpp25eXxfc6VbFOGtzxW34JcvctH2bKjj4jD4++z4R5iO5D+pg48W2e03I65A==
+"@types/fs-extra@10.1.0":
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.1.2.tgz#7125cc2e4bdd9bd2fc83005ffdb1d0ba00cca61f"
+  integrity sha512-SvSrYXfWSc7R4eqnOzbQF4TZmfpNSM9FrSWLU3EUnWBuyZqNBOrv1B1JA3byUDPUl9z4Ab3jeZG2eDdySlgNMg==
   dependencies:
-    "@types/node" "*"
-
-"@types/glob@^7.1.1":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
-  integrity sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
-  dependencies:
-    "@types/events" "*"
-    "@types/minimatch" "*"
     "@types/node" "*"
 
 "@types/istanbul-lib-coverage@^1.1.0":
@@ -1260,25 +1233,20 @@
   dependencies:
     "@types/node" "*"
 
-"@types/lodash@4.14.123":
-  version "4.14.123"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.123.tgz#39be5d211478c8dd3bdae98ee75bb7efe4abfe4d"
-  integrity sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q==
-
-"@types/minimatch@*":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
-  integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
+"@types/lodash@4.14.190":
+  version "4.14.190"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.190.tgz#d8e99647af141c63902d0ca53cf2b34d2df33545"
+  integrity sha512-5iJ3FBJBvQHQ8sFhEhJfjUP+G+LalhavTkYyrAYqz5MEJG+erSv0k9KJLb6q7++17Lafk1scaTIFXcMJlwK8Mw==
 
 "@types/node@*":
   version "11.12.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.12.2.tgz#d7f302e74b10e9801d52852137f652d9ee235da8"
   integrity sha512-c82MtnqWB/CqqK7/zit74Ob8H1dBdV7bK+BcErwtXbe0+nUGkgzq5NTDmRW/pAv2lFtmeNmW95b0zK2hxpeklg==
 
-"@types/node@12.6.2":
-  version "12.6.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.2.tgz#a5ccec6abb6060d5f20d256fb03ed743e9774999"
-  integrity sha512-gojym4tX0FWeV2gsW4Xmzo5wxGjXGm550oVUII7f7G5o4BV6c7DBdiG1RRQd+y1bvqRyYtPfMK85UM95vsapqQ==
+"@types/node@14.14.20":
+  version "14.14.20"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.20.tgz#f7974863edd21d1f8a494a73e8e2b3658615c340"
+  integrity sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -1477,22 +1445,10 @@ array-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
   integrity sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=
 
-array-union@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
-  integrity sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=
-  dependencies:
-    array-uniq "^1.0.1"
-
 array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
-
-array-uniq@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
-  integrity sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
 
 array-unique@^0.3.2:
   version "0.3.2"
@@ -1836,11 +1792,6 @@ call-bind@^1.0.0, call-bind@^1.0.2:
   dependencies:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
-
-call-me-maybe@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
-  integrity sha1-JtII6onje1y95gJQoV8DHBak1ms=
 
 callsites@^3.0.0:
   version "3.0.0"
@@ -2400,13 +2351,6 @@ diff@^4.0.1:
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
-dir-glob@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.2.2.tgz#fa09f0694153c8918b18ba0deafae94769fc50c4"
-  integrity sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==
-  dependencies:
-    path-type "^3.0.0"
-
 dir-glob@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
@@ -2748,18 +2692,6 @@ fast-deep-equal@^2.0.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
-fast-glob@^2.2.6:
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.6.tgz#a5d5b697ec8deda468d85a74035290a025a95295"
-  integrity sha512-0BvMaZc1k9F+MeWWMe8pL6YltFzZYcJsYU7D4JyDA6PAczaXvxqQQ/z+mDF7/4Mw01DeUc+i3CTKajnkANkV4w==
-  dependencies:
-    "@mrmlnc/readdir-enhanced" "^2.2.1"
-    "@nodelib/fs.stat" "^1.1.2"
-    glob-parent "^3.1.0"
-    is-glob "^4.0.0"
-    merge2 "^1.2.3"
-    micromatch "^3.1.10"
-
 fast-glob@^3.1.1:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
@@ -2919,14 +2851,14 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-fs-extra@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
-  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+fs-extra@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
+  integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
   dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-extra@^8.1.0:
   version "8.1.0"
@@ -3015,25 +2947,12 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glob-parent@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
-  integrity sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=
-  dependencies:
-    is-glob "^3.1.0"
-    path-dirname "^1.0.0"
-
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
-
-glob-to-regexp@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
-  integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
 glob@^7.0.0:
   version "7.2.0"
@@ -3094,20 +3013,6 @@ globby@^11.0.3, globby@^11.0.4:
     ignore "^5.1.4"
     merge2 "^1.3.0"
     slash "^3.0.0"
-
-globby@^9.2.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-9.2.0.tgz#fd029a706c703d29bdd170f4b6db3a3f7a7cb63d"
-  integrity sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==
-  dependencies:
-    "@types/glob" "^7.1.1"
-    array-union "^1.0.2"
-    dir-glob "^2.2.2"
-    fast-glob "^2.2.6"
-    glob "^7.1.3"
-    ignore "^4.0.3"
-    pify "^4.0.1"
-    slash "^2.0.0"
 
 got@^9.6.0:
   version "9.6.0"
@@ -3365,11 +3270,6 @@ ieee754@^1.1.13:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
-ignore@^4.0.3:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
-  integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
-
 ignore@^5.1.4:
   version "5.1.9"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.9.tgz#9ec1a5cbe8e1446ec60d4420060d43aa6e7382fb"
@@ -3609,7 +3509,7 @@ is-extendable@^1.0.1:
   dependencies:
     is-plain-object "^2.0.4"
 
-is-extglob@^2.1.0, is-extglob@^2.1.1:
+is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
@@ -3640,20 +3540,6 @@ is-glob@4.0.3, is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
-  dependencies:
-    is-extglob "^2.1.1"
-
-is-glob@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
-  integrity sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=
-  dependencies:
-    is-extglob "^2.1.0"
-
-is-glob@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
-  integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
   dependencies:
     is-extglob "^2.1.1"
 
@@ -4428,6 +4314,15 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
@@ -4668,7 +4563,7 @@ lodash@^4.17.11:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
-lodash@^4.17.19, lodash@^4.17.20, lodash@~4.17.0:
+lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@~4.17.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -4786,11 +4681,6 @@ merge-stream@^1.0.1:
   integrity sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=
   dependencies:
     readable-stream "^2.0.1"
-
-merge2@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.3.tgz#7ee99dbd69bb6481689253f018488a1b902b0ed5"
-  integrity sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==
 
 merge2@^1.3.0:
   version "1.4.1"
@@ -5336,11 +5226,6 @@ path-case@^3.0.4:
     dot-case "^3.0.4"
     tslib "^2.0.3"
 
-path-dirname@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
-  integrity sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=
-
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
@@ -5409,11 +5294,6 @@ pify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
   integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
-
-pify@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
-  integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
 pirates@^4.0.1:
   version "4.0.1"
@@ -5956,10 +5836,10 @@ shebang-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
-shelljs@^0.8.4:
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
-  integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
+shelljs@^0.8.5:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
+  integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"
@@ -6523,7 +6403,7 @@ tslint@5.14.0:
     tslib "^1.8.0"
     tsutils "^2.29.0"
 
-tsoa@^3.6.1:
+tsoa@^3.14.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/tsoa/-/tsoa-3.14.1.tgz#dd8d3e8a9c434a9f03bae5abdefcf819d58b796f"
   integrity sha512-fcGYucvQnjPEvKgxGdcsdJdsknS5JA9I/f/W30AN/yiyyMWWLvq2stM7c0gxEBAB5ICNa2dXx0sZtaQ1llwi8w==
@@ -6562,10 +6442,15 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
-typescript@^4.1.2, typescript@^4.2.0:
+typescript@^4.1.2:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
   integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
+
+typescript@^4.9.3:
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.3.tgz#3aea307c1746b8c384435d8ac36b8a2e580d85db"
+  integrity sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==
 
 ua-parser-js@^0.7.30:
   version "0.7.31"
@@ -6614,6 +6499,11 @@ universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 unixify@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Context

Make GraphQL codegen optional. It should only run if a config file is found.

This will render https://www.npmjs.com/package/serverless-plugin-tsoa unnecessary, which means we have 1 less library to maintain.